### PR TITLE
fix(sqp): Always use a new challenge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
   - master
 
 install:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
 
 script:
   - go test -v -race -timeout=10s ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
 
 script:
   - go test -v -race -timeout=10s ./...
-  - golangci-lint
+  - golangci-lint run

--- a/lib/svrquery/client_test.go
+++ b/lib/svrquery/client_test.go
@@ -54,7 +54,9 @@ func TestQuery(t *testing.T) {
 
 	c, err := NewClient(proto, addr)
 	require.NoError(t, err)
-	r, err := c.Query()
-	require.NoError(t, err)
-	fmt.Printf("%#v\n", r)
+	for i := 0; i < 5; i++ {
+		r, err := c.Query()
+		require.NoError(t, err)
+		fmt.Printf("%#v\n", r)
+	}
 }

--- a/lib/svrquery/protocol/sqp/challenge.go
+++ b/lib/svrquery/protocol/sqp/challenge.go
@@ -2,7 +2,6 @@ package sqp
 
 import (
 	"bytes"
-	"encoding/binary"
 )
 
 // Challenge sends a challenge request and validates a response
@@ -15,7 +14,7 @@ func (q *queryer) Challenge() error {
 	if err != nil {
 		return err
 	} else if pktType != ChallengeResponseType {
-		return NewErrMalformedPacketf("was expecting %v for response type, got %v", ChallengeResponseType, pktType)
+		return NewErrMalformedPacketf("was expecting 0x%02x for response type, got 0x%02x", ChallengeResponseType, pktType)
 	}
 
 	q.challengeID, err = q.readChallenge()
@@ -25,7 +24,7 @@ func (q *queryer) Challenge() error {
 // sendChallenge writes a challenge request
 func (q *queryer) sendChallenge() error {
 	pkt := &bytes.Buffer{}
-	if err := binary.Write(pkt, binary.BigEndian, ChallengeRequestType); err != nil {
+	if err := pkt.WriteByte(ChallengeRequestType); err != nil {
 		return err
 	}
 
@@ -49,7 +48,7 @@ func (q *queryer) validateChallenge() error {
 	if id, err := q.readChallenge(); err != nil {
 		return err
 	} else if id != q.challengeID {
-		return NewErrMalformedPacketf("unexpected challengeID 0x%0x wanted 0x%0x", id, q.challengeID)
+		return NewErrMalformedPacketf("was expecting 0x%04x for challengeID, got 0x%04x", q.challengeID, id)
 	}
 	return nil
 }

--- a/lib/svrquery/protocol/sqp/query.go
+++ b/lib/svrquery/protocol/sqp/query.go
@@ -157,10 +157,7 @@ func (q *queryer) readQuerySinglePacket(r *packetReader, version uint16, request
 		l -= qr.TeamInfo.ChunkLength + uint32(Uint32.Size())
 	}
 
-	if l < 0 {
-		// If we have read more bytes than expected, the packet is malformed
-		return nil, NewErrMalformedPacketf("expected packet length of %v, but have %v bytes remaining", pktLen, l)
-	} else if l > 0 {
+	if l > 0 {
 		// If we have extra bytes remaining, we assume they are new fields from a future
 		// query version and discard them.
 		if _, err := io.CopyN(ioutil.Discard, r, int64(l)); err != nil {

--- a/lib/svrquery/protocol/sqp/query.go
+++ b/lib/svrquery/protocol/sqp/query.go
@@ -47,7 +47,7 @@ func (q *queryer) sendQuery(requestedChunks byte) error {
 	}
 
 	pkt := &bytes.Buffer{}
-	if err := binary.Write(pkt, binary.BigEndian, QueryRequestType); err != nil {
+	if err := pkt.WriteByte(QueryRequestType); err != nil {
 		return err
 	}
 
@@ -59,7 +59,7 @@ func (q *queryer) sendQuery(requestedChunks byte) error {
 		return err
 	}
 
-	if err := binary.Write(pkt, binary.BigEndian, requestedChunks); err != nil {
+	if err := pkt.WriteByte(requestedChunks); err != nil {
 		return err
 	}
 
@@ -72,7 +72,7 @@ func (q *queryer) readQueryHeader() (uint16, byte, byte, uint16, error) {
 	if err != nil {
 		return 0, 0, 0, 0, err
 	} else if pktType != QueryResponseType {
-		return 0, 0, 0, 0, NewErrMalformedPacketf("was expecting %v for response type, got %v", QueryResponseType, pktType)
+		return 0, 0, 0, 0, NewErrMalformedPacketf("was expecting 0x%02x for response type, got 0x%02x", QueryResponseType, pktType)
 	}
 
 	if err = q.validateChallenge(); err != nil {

--- a/lib/svrquery/protocol/sqp/query_test.go
+++ b/lib/svrquery/protocol/sqp/query_test.go
@@ -74,7 +74,7 @@ func TestQuery(t *testing.T) {
 			// Challenge
 			buf.Reset()
 			buf.WriteByte(ChallengeResponseType)
-			binary.Write(buf, binary.BigEndian, cid)
+			require.NoError(t, binary.Write(buf, binary.BigEndian, cid))
 			chalResp := buf.Bytes()
 			m.On("Write", chalReq).Return(len(chalReq), nil).Once()
 			m.On("Read", mock.AnythingOfType("[]uint8")).Return(chalResp, nil).Once()

--- a/lib/svrquery/protocol/sqp/reader.go
+++ b/lib/svrquery/protocol/sqp/reader.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"net"
-	"time"
 	"unicode/utf8"
 )
 
@@ -63,31 +61,4 @@ func (pr *packetReader) ReadString() (int64, string, error) {
 	}
 
 	return int64(length + 1), string(buf), err
-}
-
-// deadlineReadWriter is a reader that applies a connection deadline before every read
-type deadlineReadWriter struct {
-	timeout time.Duration
-	net.Conn
-}
-
-// NewDeadlineReadWriter returns a new deadlineReadWriter
-func newDeadlineReadWriter(c net.Conn, t time.Duration) *deadlineReadWriter {
-	return &deadlineReadWriter{Conn: c, timeout: t}
-}
-
-// Read implements the io.Reader interface
-func (dr *deadlineReadWriter) Read(p []byte) (int, error) {
-	if err := dr.Conn.SetReadDeadline(time.Now().Add(dr.timeout)); err != nil {
-		return 0, err
-	}
-	return dr.Conn.Read(p)
-}
-
-// Write implements the io.Writer interface
-func (dr *deadlineReadWriter) Write(p []byte) (int, error) {
-	if err := dr.Conn.SetWriteDeadline(time.Now().Add(dr.timeout)); err != nil {
-		return 0, err
-	}
-	return dr.Conn.Write(p)
 }


### PR DESCRIPTION
Always generate a new challenge when performing a Query with SQP.

Previously we overwrote the internal challenge on receive which caused all but the first query to fail.

Also:
* Update TestQuery to run multiple queries to catch this case.